### PR TITLE
Missing file is not error for suid change protection

### DIFF
--- a/tasks/suid.yml
+++ b/tasks/suid.yml
@@ -6,7 +6,8 @@
     mode: 'a-s'
     state: file
     follow: 'yes'
-  ignore_errors: true
+  register: output
+  failed_when: "output.failed and output.state != 'absent'"
   with_items:
     - "{{ suid_sgid_blocklist }}"
   tags:


### PR DESCRIPTION
The suid change operation not failed, if the file not exists. But ansible reports the error here. Due this if failures are ignored, then info if suid change failed on existing file is supressed as not real error.

Changed the operation to not report errors when file is missing, but reports error in all other cases.

Benefit is that role output doesn't contain red lines -> then no false positives that something is wrong