### PR TITLE
Aide installation is now optional

### DIFF
--- a/defaults/main/misc.yml
+++ b/defaults/main/misc.yml
@@ -1,4 +1,5 @@
 ---
+install_aide: yes
 reboot_ubuntu: false
 redhat_rpm_key:
   - 567E347AD0044ADE55BA8A5F199E2F91FD431D51

--- a/defaults/main/packages.yml
+++ b/defaults/main/packages.yml
@@ -21,7 +21,6 @@ packages_blocklist:
   - ypbind
 packages_debian:
   - acct
-  - aide-common
   - apparmor-profiles
   - apparmor-utils
   - apt-show-versions
@@ -44,7 +43,6 @@ packages_debian:
   - tcpd
   - vlock
 packages_redhat:
-  - aide
   - audispd-plugins
   - audit
   - gnupg2

--- a/tasks/aide.yml
+++ b/tasks/aide.yml
@@ -1,4 +1,25 @@
 ---
+- name: debian family aide installation
+  become: 'yes'
+  apt:
+    name: aide-common
+    state: present
+    install_recommends: 'no'
+  when: ansible_os_family == "Debian"
+  tags:
+    - apt
+    - packages
+
+- name: redhat family aide package installation
+  become: 'yes'
+  package:
+    name: aide
+    state: present
+  when: ansible_os_family == "RedHat"
+  tags:
+    - dnf
+    - packages
+
 - name: check cron.daily aide
   become: 'yes'
   stat:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,7 +83,7 @@
 #   https://bugs.launchpad.net/ubuntu/+source/aide/+bug/1903298
 - name: configure aide
   include: aide.yml
-  when: not (ansible_distribution == "Ubuntu" and (ansible_lsb.codename == "groovy" or ansible_lsb.codename == "hirsute"))
+  when: install_aide|bool and (not (ansible_distribution == "Ubuntu" and (ansible_lsb.codename == "groovy" or ansible_lsb.codename == "hirsute")))
 
 - name: remove users
   include: users.yml


### PR DESCRIPTION
IDE is not only one option to implement the IDS. For example Wazuh or OSSEC are nice alternatives.

Then to use an alternative, make AIDE installation optional is wanted, to avoid uninstall and install another IDS

The new variable install_aide is now defined in defaults/main/misc.yml with default value true

Then role still works as expected, until user doesn't active opt-out AIDE installation.